### PR TITLE
README: Fix Opam pin URL in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Send a mail for new entries on RSS and Atom feeds
 Using OPAM:
 
 ```shell
-opam pin add rss_to_mail https://github.com/olleolleolle/rss_to_mail.git
+opam pin add rss_to_mail https://github.com/Julow/rss_to_mail.git
 ```
 
 ### Usage


### PR DESCRIPTION
Hello,

Long time no see.

I find _my_ username in the opam pin instruction - ha, that seems incorrect.

Hope things are good with you!