### PR TITLE
Parse Atom `<media:thumbnail>` and change render

### DIFF
--- a/bin/unix/print.ml
+++ b/bin/unix/print.ml
@@ -14,7 +14,8 @@ let print_feed (feed : Feed.t) =
     p "  title: %s\n" (opt Fun.id t.title);
     p "  link: %s\n" (opt Uri.to_string t.link);
     p "  summary: %s\n" (opt (fun c -> c.Feed.content_text) t.summary);
-    p "  thumbnail: %s\n" (opt Uri.to_string t.thumbnail);
+    p "  thumbnail: %s\n"
+      (opt (fun t -> Uri.to_string t.Feed.thumbnail_uri) t.thumbnail);
     p "  attachments: %s\n" (list attach_to_string t.attachments);
     ()
   in

--- a/lib/feed/Feed.ml
+++ b/lib/feed/Feed.ml
@@ -14,6 +14,12 @@ type attachment = {
   attach_type : string option;
 }
 
+type thumbnail = {
+  thumbnail_uri : Uri.t;
+  thumbnail_width : int option;
+  thumbnail_height : int option;
+}
+
 type html_name = string * string
 
 type html_content =
@@ -33,7 +39,7 @@ type entry = {
   summary : content option;
   content : content option;
   link : Uri.t option;
-  thumbnail : Uri.t option;
+  thumbnail : thumbnail option;
   date : string option;
   attachments : attachment list;
 }

--- a/lib/feed_parser/atom.ml
+++ b/lib/feed_parser/atom.ml
@@ -54,7 +54,7 @@ end
 
 let uri ~resolve_uri s = resolve_uri (Uri.of_string s)
 
-let content ~resolve_uri node =
+let decode_content ~resolve_uri node =
   match attr "type" node with
   | None | Some "text" -> Some (Feed.make_text_content (text node))
   | Some "html" -> Some (Html_content.of_html_text ~resolve_uri (text node))
@@ -77,18 +77,38 @@ let author ~resolve_uri node =
 
 let category node = { term = attr "term" node; label = attr "label" node }
 
+let media_group ~resolve_uri entry =
+  match entry <~ (media_ns, "group") with
+  | None -> (None, None)
+  | Some group ->
+      let thumbnail =
+        group <~ (media_ns, "thumbnail") >$ fun node ->
+        attr "url" node > fun url ->
+        {
+          thumbnail_uri = uri ~resolve_uri url;
+          thumbnail_width = attr "width" node >$ int_of_string_opt;
+          thumbnail_height = attr "height" node >$ int_of_string_opt;
+        }
+      in
+      (thumbnail, group <~ (media_ns, "description") > text)
+
 let entry ~resolve_uri node =
   let links = Links.of_nodes (children ~ns "link" node) in
+  let thumbnail, media_description = media_group ~resolve_uri node in
+  let content =
+    match node < "content" >$ decode_content ~resolve_uri with
+    | Some _ as c -> c
+    | None -> media_description > Feed.make_text_content
+  in
   {
     id = node < "id" > text;
     title = node < "title" > text;
-    summary = node < "summary" >$ content ~resolve_uri;
-    content = node < "content" >$ content ~resolve_uri;
+    summary = node < "summary" >$ decode_content ~resolve_uri;
+    content;
     date = node < "updated" > text;
     link = Links.(get Alternate) links > uri ~resolve_uri % fst;
     attachments = Links.(get_all Enclosure) links >> attachment ~resolve_uri;
-    thumbnail =
-      ( < ) ~ns:media_ns node "thumbnail" >$ attr "url" > uri ~resolve_uri;
+    thumbnail;
     authors = node << "author" >>$ author ~resolve_uri;
     categories = node << "category" >> category;
   }

--- a/lib/feed_parser/operators.ml
+++ b/lib/feed_parser/operators.ml
@@ -1,6 +1,7 @@
 (** Various operators used here *)
 
 let ( < ) node ?ns name = Xml.child ?ns name node
+let ( <~ ) node (ns, name) = Xml.child ~ns name node
 let ( << ) node ?ns name = Xml.children ?ns name node
 let ( > ) nopt f = Option.map f nopt
 let ( >$ ) nopt f = Option.bind nopt f

--- a/lib/rss_to_mail/mail_body.ml
+++ b/lib/rss_to_mail/mail_body.ml
@@ -16,7 +16,7 @@ module Render (Impl : sig
   val feed_icon : Uri.t -> alt:string -> inline t
   val entry_title : string -> Uri.t option -> block t
   val entry_header : inline t -> block t
-  val thumbnail_table : Uri.t -> block t -> block t
+  val thumbnail : thumbnail -> block t
   val attachment_table : inline t list -> block t
   val code_block : ?language:string -> string -> block t
   val body : sender:string -> ?hidden_summary:string -> block t list -> string
@@ -31,6 +31,7 @@ struct
     let entry_title =
       let title = Option.value ~default:"New entry" entry.title in
       entry_title title entry.link
+    and thumbnail = Option.fold ~none ~some:thumbnail entry.thumbnail
     and info_header =
       let feed_title =
         let feed_icon =
@@ -68,11 +69,7 @@ struct
       @@ [ feed_title; categories; date; authors; label ]
     in
 
-    let full_header =
-      let header = list [ entry_title; info_header ] in
-      match entry.thumbnail with
-      | Some url -> thumbnail_table url header
-      | None -> header
+    let header = list [ entry_title; thumbnail; info_header ]
     and attachments =
       let attachment index t =
         let index = string (string_of_int (index + 1)) in
@@ -94,7 +91,7 @@ struct
       | Some c -> content c
       | None -> none
     in
-    list [ full_header; attachments; content_ ]
+    list [ header; attachments; content_ ]
 
   let render_content ~sender ?label feed = function
     | `Single entry -> [ render_entry ~sender ?label feed entry ]

--- a/lib/rss_to_mail/mail_body_html.ml
+++ b/lib/rss_to_mail/mail_body_html.ml
@@ -54,14 +54,24 @@ let entry_title title entry_link =
 
 let entry_header t = [ Html.p t ]
 
-let thumbnail_table url t =
-  let thumbnail =
-    [%html
-      "<img class=\"thumbnail\" alt=\"thumbnail\" width=\"60\" height=\"60\" \
-       src="
-      (Uri.to_string url) " />"]
-  in
-  [ Html.table [ Html.tr [ Html.td [ thumbnail ]; Html.td t ] ] ]
+let thumbnail thumb =
+  let opt_attr at opt = Option.fold ~none:[] ~some:(fun x -> [ at x ]) opt in
+  Html.
+    [
+      div
+        ~a:[ a_class [ "thumbnail-container" ] ]
+        [
+          img
+            ~src:(Uri.to_string thumb.Feed.thumbnail_uri)
+            ~alt:"thumbnail"
+            ~a:
+              (opt_attr a_width thumb.thumbnail_width
+              @ opt_attr a_height thumb.thumbnail_height
+              )
+            ();
+        ];
+    ]
+  
 
 let attachment_table =
   let attachment ts =
@@ -101,7 +111,8 @@ a { text-decoration: none; }
 .entry_header { margin-top: 0; }
 .content { margin: 20px 0 25px 10px; max-width: 600px; }
 .content img { max-width: 100%; max-height: auto; }
-.thumbnail { display: block; margin: 0 5px 5px 0; width: 60px; height: 60px; }
+.thumbnail-container { margin: 20px 0 20px 0; max-width: 600px; }
+.thumbnail-container img { display: block; margin: 0 auto; }
     </style>
     <title>|}
          (Html.txt sender) {|</title>

--- a/lib/rss_to_mail/mail_body_text.ml
+++ b/lib/rss_to_mail/mail_body_text.ml
@@ -53,7 +53,10 @@ let entry_header t k =
   t k;
   k "\n\n"
 
-let thumbnail_table _thumbnail rhs k = rhs k
+let thumbnail th k =
+  k "Thumbnail: ";
+  k (Uri.to_string th.Feed.thumbnail_uri);
+  k "\n\n"
 
 let attachment_table ts k =
   match ts with

--- a/lib/scraper/scraper.ml
+++ b/lib/scraper/scraper.ml
@@ -37,7 +37,15 @@ let scrap_entry ~parse_uri node t = function
   | Summary ->
       let summary = String.concat "\n" (Soup.trimmed_texts node) in
       { t with summary = Some (Feed.make_text_content summary) }
-  | Thumbnail -> { t with thumbnail = uri ~parse_uri node ||| t.thumbnail }
+  | Thumbnail ->
+      let thumbnail =
+        match uri ~parse_uri node with
+        | Some thumbnail_uri ->
+            Some
+              { thumbnail_uri; thumbnail_width = None; thumbnail_height = None }
+        | None -> t.thumbnail
+      in
+      { t with thumbnail }
   | Attachment { attach_type } ->
       let attachments =
         match uri ~parse_uri node with


### PR DESCRIPTION
Code existed to parse and print the thumbnail but unfortunately it didn't parse anything.

The `<media:thumbnail>` element is nested into the `<media:group>` entry element.

The HTML rendering is changed to render the thumbnail as a block element below the title instead of a small 60 x 60 image embedded in the header line.

The Text rendering renders the thumbnail URL.